### PR TITLE
Return list of items for root directory

### DIFF
--- a/ezshare/__main__.py
+++ b/ezshare/__main__.py
@@ -34,8 +34,10 @@ class ezshare():
 
     def listdir(self, dir, recursive=False, shift=0):
         ret = {}
+        is_root = False
         if dir=="/":
             dir=""
+            is_root = True
         dir=dir.replace("/","\\")
         soup = self._get(f"{self.base}{dir}")
         has_dotiles=False
@@ -53,7 +55,8 @@ class ezshare():
                         ret[name] = dir_content
             else:
                 ret[name] = href
-        if not has_dotiles: #No dotfiles or ezshare.cfg? This must not be a directory
+        #No dotfiles or ezshare.cfg and is not root? This must not be a directory
+        if not has_dotiles and not is_root: 
             return None
         return ret
 


### PR DESCRIPTION
I recently erase data from my card and it stops showing dot files or ezshare.cfg for root directory.

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
<meta name="format-detection" content="telephone=no">
<meta http-equiv="Content-Language" content="zh-cn">
<meta http-equiv="Content-Type" content="text/html; charset=gb2312">
<link rel="shortcut icon" href="i-share/img/favicon.ico" type="image/x-icon">
<link rel="icon" href="i-share/img/favicon.ico" type="image/x-icon">
<title>Index of A:</title>
</head>
<body>
<h1><a href="photo">back to photo</a></h1>
<h1>Directory Index of A:</h1>
<pre>
   2023-12-18   22:42:10          64KB  <a href="http://192.168.4.1/download?file=JOURNAL.DAT"> Journal.dat</a>
   2023-12-18   22:42:24           1KB  <a href="http://192.168.4.1/download?file=IDNK8C~1.TGT"> Identification.tgt</a>
   2023-12-18   22:42:24           1KB  <a href="http://192.168.4.1/download?file=ID34E8~1.CRC"> Identification.crc</a>
   2023-12-18   22:42:24         &lt;DIR&gt;   <a href="dir?dir=A:%5CDATALOG"> DATALOG</a>
   2023-12-18   22:42:24         &lt;DIR&gt;   <a href="dir?dir=A:%5CSETTINGS"> SETTINGS</a>
   2023-12-24   12:10: 0          27KB  <a href="http://192.168.4.1/download?file=STR.EDF"> STR.edf</a>

Total Entries: 6
Total Size: 93KB
</pre>
</body>
</html>
```