### PR TITLE
remove crc32 check feature

### DIFF
--- a/ezshare/__main__.py
+++ b/ezshare/__main__.py
@@ -22,7 +22,6 @@ class ezshare():
         return not self.is_dir(href)
 
     def _get(self, url):
-        #print(f"GET {url}")
         return parse_url(url)
 
     def ping(self):
@@ -77,13 +76,14 @@ class ezshare():
         stream.seek(pos)
         return ln - pos
 
-    def _dload(self, link, file_name, crc):
+    def _dload(self, link, file_name):
         with open(file_name, "a+b") as f:
             f.seek(0)
             response = requests.head(link)
             curlength = self.stream_size(f)
             total_length = int(response.headers.get('content-length'))
-            if not crc and curlength == total_length:
+            
+            if curlength == total_length:
                 print(f"Skipping file {file_name} (same size)")
                 return True        
 
@@ -92,12 +92,6 @@ class ezshare():
                 f.truncate()
                 f.write(response.content)
                 return True
-            elif crc and curlength == total_length:
-                f_crc32_hash = binascii.crc32(f.read())
-                r_crc32_hash = binascii.crc32(response.content)
-                if f_crc32_hash == r_crc32_hash:
-                    print(f"Skipping file {file_name} (same crc32 sum)")
-                    return True
 
             total_length = int(total_length)
             with tqdm(desc=file_name, total=total_length, unit='B', unit_scale=True, unit_divisor=1024, miniters=1) as pbar:
@@ -107,11 +101,11 @@ class ezshare():
                     pbar.update(len(data))
             return True
 
-    def _dload_with_retry(self, link, file_name, crc):
+    def _dload_with_retry(self, link, file_name):
         last_exception = None
         for retries in range(self.num_retries):
             try:
-                return self._dload(link, file_name, crc)
+                return self._dload(link, file_name)
             except (requests.exceptions.ConnectionError, requests.exceptions.ChunkedEncodingError) as err:
                 print(f"Retrying link: {link} ({retries} times)")
                 last_exception = err
@@ -119,7 +113,7 @@ class ezshare():
             print(f"Failed to download {link}: {last_exception}")
         return False
 
-    def download(self, remote_file, local_file=None, recursive=False, crc=False):
+    def download(self, remote_file, local_file=None, recursive=False):
         if local_file == None:
             local_file = path.basename(remote_file)
         if local_file[-1]=="/":
@@ -129,27 +123,27 @@ class ezshare():
         remote_dir = path.dirname(remote_file)
         basename = path.basename(remote_file)
         link = self.listdir(remote_dir, recursive)[basename]
-        self._dload_with_retry(link, local_file, crc)
+        self._dload_with_retry(link, local_file)
 
-    def _sync_list(self, todo, local_dir, crc):
+    def _sync_list(self, todo, local_dir):
         os.makedirs(local_dir, exist_ok=True)
         for k,v in todo.items():
             if type(v) is dict:
-                self._sync_list(v, path.join(local_dir, k), crc)
+                self._sync_list(v, path.join(local_dir, k))
             elif v:
-                self._dload_with_retry(v, path.join(local_dir, k), crc)
+                self._dload_with_retry(v, path.join(local_dir, k))
             else:
                 print(f"Skipping sync of {k} because link is {v}")
 
-    def sync(self, remote_dir, local_dir=".", recursive=False, crc=False):
+    def sync(self, remote_dir, local_dir=".", recursive=False):
         if local_dir == None:
             local_dir = "."
 
         todo = self.listdir(remote_dir, recursive=recursive)
         if todo is None:
-            self.download(remote_dir, local_dir, crc=crc)
+            self.download(remote_dir, local_dir)
         else:
-            self._sync_list(todo, local_dir, crc)
+            self._sync_list(todo, local_dir)
 
 def _handle_args_once(args, s):
     if args.wait:
@@ -168,7 +162,7 @@ def _handle_args_once(args, s):
         s.print_list(d)
     if not args.download is None:
         print(f"Synchronizing remote {args.download} -> {args.target}")
-        s.sync(args.download, args.target, recursive=args.recursive, crc=args.crc)
+        s.sync(args.download, args.target, recursive=args.recursive)
     
 def main():
     import argparse
@@ -180,7 +174,6 @@ def main():
     parser.add_argument('-r', '--recursive', action="store_true", default=False, help="Recurse to subdirs on list/download")
     parser.add_argument('-t', '--target', default=".", help="Specify target directory for downloads")
     parser.add_argument('-w', '--wait',  action="store_true", default=False, help="Wait for WiFi SD to appear on the network")
-    parser.add_argument('-c', '--crc', action="store_true", default=False, help="Enable CRC check on files")
     parser.add_argument('--live', type=int, default=-1, help="Live mode. Don't exit after syncronisation."
                                                              "The argument specifies cooldown in seconds between sync. See docs for details")
 


### PR DESCRIPTION
After experimenting further with crc32, I came to the realization that it doesn't serve much purpose. This is due to the fact that in order to calculate the hash, we must first read the response fully. And since the response is already read, checking the hash doesn't really save us any time or effort.